### PR TITLE
Aidand llama stack on cpu - Scratch PR

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+export INFERENCE_MODEL="meta-llama/Llama-3.2-3B-Instruct"
+# ollama names this model differently, and we must use the ollama name when loading the model
+export OLLAMA_INFERENCE_MODEL="llama3.2:3b-instruct-fp16"
+export LLAMA_STACK_PORT=5001

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ Package.resolved
 .vscode
 _build
 docs/src
-.envs/
+envs/

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ Package.resolved
 .vscode
 _build
 docs/src
+.envs/

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -1,0 +1,16 @@
+```bash
+export INFERENCE_MODEL="meta-llama/Llama-3.2-3B-Instruct"
+# ollama names this model differently, and we must use the ollama name when loading the model
+export OLLAMA_INFERENCE_MODEL="llama3.2:3b-instruct-fp16"
+export LLAMA_STACK_PORT=5001
+ollama run $OLLAMA_INFERENCE_MODEL --keepalive 60m
+
+docker run \
+  -it \
+  -p $LLAMA_STACK_PORT:$LLAMA_STACK_PORT \
+  -v ~/.llama:/root/.llama \
+  llamastack/distribution-ollama \
+  --port $LLAMA_STACK_PORT \
+  --env INFERENCE_MODEL=$INFERENCE_MODEL \
+  --env OLLAMA_URL=http://host.docker.internal:11434
+```

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -14,9 +14,20 @@ docker run \
   --env INFERENCE_MODEL=$INFERENCE_MODEL \
   --env OLLAMA_URL=http://host.docker.internal:11434
 
+
+
 source ~/miniconda3/bin/activate
 conda create --prefix envs python=3.10
+
+source ~/miniconda3/bin/activate
 conda activate ./envs
+
+# Run from source
+llama stack build --template ollama --image-type conda
+llama stack run ./distributions/ollama/run.yaml \
+  --port $LLAMA_STACK_PORT \
+  --env INFERENCE_MODEL=$INFERENCE_MODEL \
+  --env OLLAMA_URL=http://localhost:11434
 
 pip install .
 

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -19,4 +19,8 @@ conda create --prefix envs python=3.10
 conda activate ./envs
 
 pip install .
+
+llama-stack-client --endpoint http://localhost:$LLAMA_STACK_PORT \
+  inference chat-completion \
+  --message "hello, what model are you?"
 ```

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -13,4 +13,10 @@ docker run \
   --port $LLAMA_STACK_PORT \
   --env INFERENCE_MODEL=$INFERENCE_MODEL \
   --env OLLAMA_URL=http://host.docker.internal:11434
+
+source ~/miniconda3/bin/activate
+conda create --prefix envs python=3.10
+conda activate ./envs
+
+pip install .
 ```


### PR DESCRIPTION
500 error

<img width="891" alt="image" src="https://github.com/user-attachments/assets/da7c8060-c7e1-4b3b-8955-8427391ea473">

```
Traceback (most recent call last):
  File "/Users/aidand/dev/llama-stack/llama_stack/distribution/server/server.py", line 187, in endpoint
    return await maybe_await(value)
  File "/Users/aidand/dev/llama-stack/llama_stack/distribution/server/server.py", line 151, in maybe_await
    return await value
  File "/Users/aidand/dev/llama-stack/llama_stack/distribution/tracing.py", line 88, in async_wrapper
    result = await method(self, *args, **kwargs)
  File "/Users/aidand/dev/llama-stack/llama_stack/distribution/routers/routers.py", line 123, in chat_completion
    return await provider.chat_completion(**params)
  File "/Users/aidand/dev/llama-stack/llama_stack/distribution/tracing.py", line 88, in async_wrapper
    result = await method(self, *args, **kwargs)
  File "/Users/aidand/dev/llama-stack/llama_stack/providers/remote/inference/ollama/ollama.py", line 220, in chat_completion
    return await self._nonstream_chat_completion(request)
  File "/Users/aidand/dev/llama-stack/llama_stack/providers/remote/inference/ollama/ollama.py", line 272, in _nonstream_chat_completion
    assert isinstance(r, dict)
AssertionError
INFO:     ::1:51826 - "POST /alpha/inference/chat-completion HTTP/1.1" 500 Internal Server Error
```